### PR TITLE
Adding explicit clarification on acceptable header values

### DIFF
--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -102,6 +102,11 @@ As a result, it is essential that the RPs follow proper REST guidelines when ret
 ## Asynchronous Operations ##
 
 Some REST operations can take a long time to complete. Although REST is not supposed to be stateful, some operations are made asynchronous while waiting for the state machine to create the resources, and will reply before the operation on resources are completed. For such operations, the following guidance applies.
+* All header values provided follows [RFC2616, Section14](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
+
+    * Location header should be absolute URI
+    * Retry-After should be (integer), will not support http-date
+    * Azure-AsyncOperation header should be absolute URI
 
 ## Creating or Updating Resources ##
 

--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -102,11 +102,12 @@ As a result, it is essential that the RPs follow proper REST guidelines when ret
 ## Asynchronous Operations ##
 
 Some REST operations can take a long time to complete. Although REST is not supposed to be stateful, some operations are made asynchronous while waiting for the state machine to create the resources, and will reply before the operation on resources are completed. For such operations, the following guidance applies.
-* All header values provided follows [RFC2616, Section14](http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html)
 
-    * Location header should be absolute URI
+**Please note:**
+
+    * Location header should be absolute URI (partial URI is not supported)
     * Retry-After should be (integer), will not support http-date
-    * Azure-AsyncOperation header should be absolute URI
+    * Azure-AsyncOperation header should be absolute URI (partial URI is not supported)
 
 ## Creating or Updating Resources ##
 


### PR DESCRIPTION
Clarifying few things that can be interpreted differently.
1. Specifying we are following a particular RFC for header values
2. Specifying what kind of URLs will be accepted in header (Azure-AsycnOperation and Header location)
3. Specifying if retry-after can accept http-date as a valid interval.

For retry-after, the following section specifies that the min/max values will be in the range of 10 sec/10 mins
https://github.com/shahabhijeet/azure-resource-manager-rpc/blob/master/v1.0/Addendum.md#202-accepted-and-location-headers