### PR TITLE
Guidance to include Retry-After for retryable call

### DIFF
--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -261,7 +261,7 @@ The recommended pattern for REST clients is to retry calls that:
 3. Experience a socket exception (e.g. DNS resolution failures; network drop; no listening socket).
 4. Any other response where a Retry-After header is present.
 
-The retry interval, strategy (e.g. exponential/linear) and max timeout should be defined by the _server_ and not the client. The server indicates how long it expects the client to wait before retryint the call by including a (Retry-After header)[https://tools.ietf.org/html/rfc7231#section-7.1.3] in the response. That allows various server workloads to advertise different retry policies.
+The retry interval, strategy (e.g. exponential/linear) and max timeout should be defined by the _server_ and not the client. The server indicates how long it expects the client to wait before retrying the call by including a (Retry-After header)[https://tools.ietf.org/html/rfc7231#section-7.1.3] in the response. That allows various server workloads to advertise different retry policies.
 
 ## Designing Resources ##
 

--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -259,8 +259,9 @@ The recommended pattern for REST clients is to retry calls that:
 1. Return 408 indicating a request timeout;
 2. Return a 5xx status code indicating a server failure (e.g. 500 InternalServerError; 503 Service Unavailable);
 3. Experience a socket exception (e.g. DNS resolution failures; network drop; no listening socket).
+4. Any other response where a Retry-After header is present.
 
-The retry interval, strategy (e.g. exponential/linear) and max timeout should be defined by the _server_ and not the client. That allows various server workloads to advertise different retry policies.
+The retry interval, strategy (e.g. exponential/linear) and max timeout should be defined by the _server_ and not the client. The server indicates how long it expects the client to wait before retryint the call by including a (Retry-After header)[https://tools.ietf.org/html/rfc7231#section-7.1.3] in the response. That allows various server workloads to advertise different retry policies.
 
 ## Designing Resources ##
 


### PR DESCRIPTION
Include guidance for clients to retry on any call that includes a Retry-After header.