### PR TITLE
Adding manageByTenants to subscription lifecycle notification reference

### DIFF
--- a/v1.0/subscription-lifecycle-api-reference.md
+++ b/v1.0/subscription-lifecycle-api-reference.md
@@ -39,6 +39,11 @@ This API uses the &quot;system&quot; version of 2.0 because it can be triggered 
             "state": "Registered"
           }
         ]
+        "managedByTenants": [
+          {
+            "tenantId": "<managedByTenantId>"
+          }
+        ]
       }
     }
 
@@ -49,7 +54,8 @@ This API uses the &quot;system&quot; version of 2.0 because it can be triggered 
 | **properties.tenantId** | Optional.The AAD directory/tenant to which the subscription belongs. |
 | **properties.locationPlacementId** | Optional.The placement requirement for the subscription based on its country of origin / offer type / offer category / etc. This is used in geo-fencing of certain regions or regulatory boundaries (e.g. Australia ring-fencing). |
 | **properties.quotaId** | Optional.The quota requirement for the subscription based on the offer type / category (e.g. free vs. pay-as-you-go). This can be used to inform quota information for the subscription (e.g. max # of resource groups or max # of virtual machines. |
-| **Properties.registeredFeatures** | Optional.All AFEC features that the subscriptions has been registered under RP namespace and platform namespace (Microsoft.Resources).  Null or an empty array would mean that there are no registered features in the subscription. |
+| **Properties.registeredFeatures** | Optional.All AFEC features that the subscriptions has been registered under RP namespace and platform namespace (e.g. Microsoft.Resources).  Null or an empty array would mean that there are no registered features in the subscription. |
+| **Properties.managedByTenants** | Optional.All tenants managing the subscription. Null or empty means that there are no managing tenants. |
 
 ### Response
 


### PR DESCRIPTION
Adding managedByTenants to RPC docs to reflect changes made to subscription lifecycle notification payload