### PR TITLE
Update error response body example

### DIFF
--- a/v1.0/common-api-details.md
+++ b/v1.0/common-api-details.md
@@ -89,38 +89,41 @@ The resource providers must return the \*code\* and \*message\* fields; however,
 
 **Response Body**
 ```
-    {
-    "error": {
+{
+  "error": {
+    "code": "",
+    "message": "",
+    "target": "",
+    "additionalInfo": [],
+    "details": [
+      {
         "code": "",
-        "message": "",
         "target": "",
-        "additionalInfo": [],
-        "details": [
+        "message": "",
+        "additionalInfo": [
           {
-            "code": "",
-            "target": "",
-            "message": "",
-            "additionalInfo": [
-                {
-                    "type": "PolicyViolation",
-                    "info": {
-                        "policySetDefinitionDisplayName": "Secure the environment",
-                        "policySetDefinitionId":"/subscriptions/00000-00000-0000-000/providers/Microsoft.Authorization/policySetDefinitions/TestPolicySet",
-                        "policyDefinitionDisplayName": "Allowed locations",
-                        "policyDefinitionId":"/subscriptions/00000-00000-0000-000/providers/Microsoft.Authorization/policyDefinitions/TestPolicy1",
-                        "policyAssignmentDisplayName": "Allow Central US and WEU only",
-                        "policyAsssignmentId":"/subscriptions/00000-00000-0000-000/providers/Microsoft.Authorization/policyAssignments/TestAssignment1"
-                    },
-                    "type": "SomeOtherViolation",
-                    "info": {
-                      "innerException": "innerException Details"
-                    }
-                  }
-              ]
+            "type": "PolicyViolation",
+            "info": {
+              "policySetDefinitionDisplayName": "Secure the environment",
+              "policySetDefinitionId": "/subscriptions/00000-00000-0000-000/providers/Microsoft.Authorization/policySetDefinitions/TestPolicySet",
+              "policyDefinitionDisplayName": "Allowed locations",
+              "policyDefinitionId": "/subscriptions/00000-00000-0000-000/providers/Microsoft.Authorization/policyDefinitions/TestPolicy1",
+              "policyAssignmentDisplayName": "Allow Central US and WEU only",
+              "policyAsssignmentId": "/subscriptions/00000-00000-0000-000/providers/Microsoft.Authorization/policyAssignments/TestAssignment1"
+            }
+          },
+          {
+            "type": "SomeOtherViolation",
+            "info": {
+              "innerException": "innerException Details"
+            }
           }
         ]
       }
-    }
+    ]
+  }
+}
+    
 ```
 | Element name | Type | Description |
 | --- | --- | --- |


### PR DESCRIPTION
According to common-api-details.md

additionalInfo is "An array of objects with "type" (string), and "info" (object) properties. The schema of "info" is service-specific and dependent on the "type" string."

However the example showed an array of one object with duplicate (overwritten) type and info fields