### PR TITLE
Add expectation for RP to return empty collection explicitly in case of all parent types existing in the case of Get resource collection under subscription

### DIFF
--- a/v1.0/resource-api-reference.md
+++ b/v1.0/resource-api-reference.md
@@ -311,7 +311,7 @@ If the resource does not exist, 404 (NotFound) should be returned. For other err
 
 If the resource group does not exist, 404 (NotFound) will be returned by the proxy \*without\* reaching the resource provider.
 
-If the subscription does not exist, 404 (NotFound) will be returned by the proxy \*without\* reaching the resource provider. If the subscription is not registered with the resource provider, it should return a 404 (NotFound) or an empty collection. It must not return a 5xx status code or 403.
+If the subscription does not exist, 404 (NotFound) will be returned by the proxy \*without\* reaching the resource provider. If the subscription is not registered with the resource provider, it should return a 404 (NotFound) or an empty collection. When there are no types and all parent entities exist, it should return an empty collection. It must not return a 5xx status code or 403.
 
 **Response Headers**
 


### PR DESCRIPTION
Currently ARM expects 200 with an empty collection in case of a Get resource collection under subscription when all the parent entities exist, but that is not stated explicitly. Some RPs are returning 404s which is causing issues in case of syncing resources under a subscription.

This change aims to explicitly list the requirement.