### PR TITLE
Clarify PATCH async behavior

### DIFF
--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -111,31 +111,41 @@ Some REST operations can take a long time to complete. Although REST is not supp
 
 ## Creating or Updating Resources ##
 
-The API flow for PUT/PATCH should be to:
+The API flow for PUT should be to:
 
-1. Respond to the initial PUT request with a 201 Created or 200 OK (per normal guidance);
-2. Since provisioning is not complete, the PUT response body **MUST** contain a provisioningState set to a non-terminal value (e.g. &quot;Accepted&quot;, or &quot;Created&quot;);
-3. **Optional** : The response headers may include a Azure-AsyncOperation header pointing to an Operation resource (as described below);
-4. Future GETs on the resource that was created should continue to return a 200 Status Code and provisioningState field that is \*non-terminal\* as long as the provisioning is in progress;
+1. Respond to the initial PUT request with a 201 Created or 200 OK (per normal guidance)
+2. Since provisioning is not complete, the PUT response body **MUST** contain a provisioningState set to a non-terminal value (e.g. &quot;Accepted&quot;, or &quot;Created&quot;)
+3. **Optional** : The response headers may include a Azure-AsyncOperation header pointing to an Operation resource (as described below)
+4. Future GETs on the resource that was created should continue to return a 200 Status Code and provisioningState field that is \*non-terminal\* as long as the provisioning is in progress
 5. After the provisioning completes, the provisioningState field should transition to one of the terminal states (as described below).
 6. The provisioningState field should be returned on all future GETs, even after it is complete, until some other operation (e.g. a DELETE or UPDATE) causes it to transition to a non-terminal state.
+
+## Patch Resource ##
+
+The API flow for PATCH on an existing resource should be to:
+
+1. Respond to the initial PATCH request with a 202 Accepted
+2. The response headers **MUST** include a Location header that points to a URL where the ongoing operation can be monitored
+3. **Optional:** The response headers may include an Azure-AsyncOperation header pointing to an Operation resource (as described below).
+4. If a provisioningState field is used for the resource, it **MUST** transition to a non-terminal state like &quot;Updating&quot;
+5. If the PATCH completes successfully, the URL that was returned in the Location header **MUST** now return what would have been a successful response if the API completed (e.g. a response body / header / status code).
 
 ## Delete Resource ##
 
 The API flow should be to:
 
-1. Respond to the initial DELETE request with a 202 Accepted;
-2. The response headers **MUST** include a Location header that points to a URL where the ongoing operation can be monitored;
+1. Respond to the initial DELETE request with a 202 Accepted
+2. The response headers **MUST** include a Location header that points to a URL where the ongoing operation can be monitored
 3. **Optional:** The response headers may include an Azure-AsyncOperation header pointing to an Operation resource (as described below).
-4. If a provisioningState field is used for the resource, it **MUST** transition to a non-terminal state like &quot;Deleting&quot;;
+4. If a provisioningState field is used for the resource, it **MUST** transition to a non-terminal state like &quot;Deleting&quot;
 5. If the DELETE completes successfully, the URL that was returned in the Location header **MUST** now return a 200 OK or 204 NoContent to indicate success and the resource **MUST** disappear.
 
 ## Call Action POST ##
 
 The API flow for POST {resourceUrl}/{action} should be:
 
-1. Respond to the initial POST request with a 202 Accepted;
-2. The response headers **MUST** include a Location header that points to a URL where the ongoing operation can be monitored;
+1. Respond to the initial POST request with a 202 Accepted
+2. The response headers **MUST** include a Location header that points to a URL where the ongoing operation can be monitored
 3. **Optional:** The response headers may include an Azure-AsyncOperation header pointing to an Operation resource (as described below).
 4. If the POST completes successfully, the URL that was returned in the Location header **MUST** now return what would have been a successful response if the API completed (e.g. a response body / header / status code). It is acceptable for this to be a 200/204 NoContent if the action does not require a response (e.g. restarting a VM).
 

--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -7,9 +7,9 @@
 - [Nested Resources](#nested-resources) <br/>
 - [Resource Group Deletes](#resource-group-deletes) <br/>
 - [Asynchronous Operations](#asynchronous-operations) <br/>
-- [Creating or Updating Resources](#creating-or-updating-resources)
-- [Delete Resource](#delete-resource)
-- [Call Action POST](#call-action-post)
+- [Creating or Updating Resources Asynchronously](#creating-or-updating-resources-asynchronously)
+- [Delete Resource Asynchronously](#delete-resource-asynchronously)
+- [Call Action POST Asynchronously](#call-action-post-asynchronously)
 - [ProvisioningState property](#provisioningstate-property)
 - [202 Accepted and Location Headers](#202-accepted-and-location-headers)
 - [Operation Resource format](#operation-resource-format)

--- a/v1.0/Addendum.md
+++ b/v1.0/Addendum.md
@@ -109,7 +109,9 @@ Some REST operations can take a long time to complete. Although REST is not supp
     * Retry-After should be (integer), will not support http-date
     * Azure-AsyncOperation header should be absolute URI (partial URI is not supported)
 
-## Creating or Updating Resources ##
+## Creating or Updating Resources Asynchronously ##
+
+### Creating/Updating using PUT ###
 
 The API flow for PUT should be to:
 
@@ -120,7 +122,7 @@ The API flow for PUT should be to:
 5. After the provisioning completes, the provisioningState field should transition to one of the terminal states (as described below).
 6. The provisioningState field should be returned on all future GETs, even after it is complete, until some other operation (e.g. a DELETE or UPDATE) causes it to transition to a non-terminal state.
 
-## Patch Resource ##
+### Updating using PATCH ###
 
 The API flow for PATCH on an existing resource should be to:
 
@@ -130,7 +132,7 @@ The API flow for PATCH on an existing resource should be to:
 4. If a provisioningState field is used for the resource, it **MUST** transition to a non-terminal state like &quot;Updating&quot;
 5. If the PATCH completes successfully, the URL that was returned in the Location header **MUST** now return what would have been a successful response if the API completed (e.g. a response body / header / status code).
 
-## Delete Resource ##
+## Delete Resource Asynchronously ##
 
 The API flow should be to:
 
@@ -140,7 +142,7 @@ The API flow should be to:
 4. If a provisioningState field is used for the resource, it **MUST** transition to a non-terminal state like &quot;Deleting&quot;
 5. If the DELETE completes successfully, the URL that was returned in the Location header **MUST** now return a 200 OK or 204 NoContent to indicate success and the resource **MUST** disappear.
 
-## Call Action POST ##
+## Call Action POST Asynchronously ##
 
 The API flow for POST {resourceUrl}/{action} should be:
 

--- a/v1.0/resource-api-reference.md
+++ b/v1.0/resource-api-reference.md
@@ -37,7 +37,7 @@ ARM does not distinguish between creation and update. The resource provider shou
 
 **Arguments**
 
-[Description here](#arguments-for-crud-on-resource).
+[Common Arguments](#arguments-for-crud-on-resource).
 
 The resource group names and resource names should be matched case insensitively. That means, for example, if a user creates a resource in resource group &quot;rG1&quot;, and then calls a read operation on &quot;RG1&quot;, the same resource should be returned even though the casing differs.
 
@@ -142,7 +142,7 @@ The response includes an HTTP status code, a set of response headers, and a resp
 
 The resource provider should return 200 (OK) or 201 (Created) to indicate that the operation completed successfully synchronously.
 
-If the create request cannot be fulfilled quickly, the RP should return and follow the _Asynchronous Operations_ addendum. The resource provider can return 202 (Accepted) in these cases, but 201 + provisioningState is generally preferred.
+If the create request cannot be fulfilled quickly, the RP should return and follow the [_Asynchronous Operations_ addendum](Addendum.md#asynchronous-operations). The resource provider can return 202 (Accepted) in these cases, but 201 + provisioningState is generally preferred.
 
 If the subscription or the resource group does not exist, 404 (NotFound) should be returned.
 
@@ -172,7 +172,7 @@ Updates a resource belonging to a resource group. ARM requires RPs to support PA
 
 **Arguments**
 
-[Description here](#arguments-for-crud-on-resource).
+[Common Arguments](#arguments-for-crud-on-resource).
 
 **Request Body**
 
@@ -190,7 +190,7 @@ The response includes an HTTP status code, a set of response headers, and a resp
 
 **Status Code**
 
-The resource provider should return 200 (OK) to indicate that the operation completed successfully. 202 (Accepted) can be returned to indicate that the operation will complete asynchronously.
+The resource provider should return 200 (OK) to indicate that the operation completed successfully. 202 (Accepted) can be returned to indicate that the operation will complete [asynchronously](Addendum.md#asynchronous-operations).
 
 If the resource group \*or\* resource does not exist, 404 (NotFound) should be returned.
 
@@ -200,7 +200,7 @@ Headers common to all responses.
 
 **Response Body**
 
-The response body will contain the updated resource (using the existing value + the request in the PATCH) per the Azure REST guidelines [here] (https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md).
+The response body will contain the updated resource (using the existing value + the request in the PATCH) per the Azure REST guidelines [here](https://github.com/Microsoft/api-guidelines/blob/master/Guidelines.md).
 
 ##### Representing SKUs #####
 
@@ -227,7 +227,7 @@ Deletes a resource from the resource group.
 
 **Arguments**
 
-[Description here](#arguments-for-crud-on-resource).
+[Common Arguments](#arguments-for-crud-on-resource).
 
 **Request Headers**
 
@@ -245,7 +245,7 @@ The response includes an HTTP status code, a set of response headers, and a resp
 
 The resource provider can return 200 (OK) or 204 (NoContent) to indicate that the operation completed successfully. A 200 (OK) should be returned if the object exists and was deleted successfully; and a 204 (NoContent) should be used if the resource does not exist and the request is well formed.
 
-202 (Accepted) can be returned to indicate that the operation will complete asynchronously.
+202 (Accepted) can be returned to indicate that the operation will complete [asynchronously](Addendum.md#asynchronous-operations).
 
 If the resource group does not exist, 404 (NotFound) will be returned by the proxy layer and will not reach the resource provider. 412 (PreconditionFailed) and other normal REST codes are acceptable as long as they match the REST guidelines.
 
@@ -289,7 +289,7 @@ This allows the resource provider to remain regional and still support this quer
 
 **Arguments**
 
-[Description here](#arguments-for-crud-on-resource).
+[Common Arguments](#arguments-for-crud-on-resource).
 
 **Request Headers**
 
@@ -404,7 +404,7 @@ As some examples: (1) the website RP may require that all websites belonging to 
 
 **Arguments**
 
-[Description here](#arguments-for-crud-on-resource).
+[Common Arguments](#arguments-for-crud-on-resource).
 
 
 **Request Headers**
@@ -453,7 +453,7 @@ ARM will perform some basic validation before forwarding the request to the reso
 
 If the request reaches the resource provider, it should return 200 (OK) to indicate that the operation completed successfully.
 
-202 (Accepted) can be returned to indicate that the operation will [complete asynchronously](Addendum.md#async-id).
+202 (Accepted) can be returned to indicate that the operation will [complete asynchronously](Addendum.md#asynchronous-operations).
 
 If the resource group \*or\* resource does not exist, 404 (NotFound) should be returned. A 400 (BadRequest) can be used if the request does not satisfy the RP specific requirements.
 

--- a/v1.0/subscription-lifecycle-api-reference.md
+++ b/v1.0/subscription-lifecycle-api-reference.md
@@ -67,7 +67,7 @@ The response includes an HTTP status code, a set of response headers, and a resp
 
 **Status Code**
 
-The resource provider should return 200 (OK) to indicate that the operation completed successfully. 202 (Accepted) can be returned to indicate that the operation will [complete asynchronously](Addendum.md#async-id).
+The resource provider should return 200 (OK) to indicate that the operation completed successfully. 202 (Accepted) can be returned to indicate that the operation will [complete asynchronously](Addendum.md#asynchronous-operations).
 
 The location header is not followed as part of the notification; instead, the notification will be retried with a delay. It is expected that subsequent updates that are a no-op will complete synchronously.
 


### PR DESCRIPTION
Clarify that PATCH requests should follow the 202 + location header async pattern (instead of 200 + provisioningState).  

The RPC contradicted itself between the async operations addendum and the PATCH operation section in the resource API reference.