### PR TITLE
Update to Proxy API reference

### DIFF
--- a/v1.0/proxy-api-reference.md
+++ b/v1.0/proxy-api-reference.md
@@ -140,7 +140,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
     {
       "name": "{resourceProviderNamespace}/{resourceType}/{read|write|delete|action}",
       "isDataAction": false,
-      "actionType" : "internalAction",
+      "actionType" : "InternalAction",
       "display": {
         "provider": "{Name of the provider for display purposes}",
         "resource": "{Name of the resource type for display purposes}",
@@ -154,7 +154,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
     {
       "name": "{resourceProviderNamespace}/{resourceType}/{read|write|delete|action}",
       "isDataAction": false,
-      "actionType" : "internalAction",
+      "actionType" : "InternalAction",
       "display": {
         "provider": "{Name of the provider for display purposes}",
         "resource": "{Name of the resource type for display purposes}",
@@ -179,7 +179,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
 | display.description | **Required**.The localized friendly description for the operation, as it should be shown to the user. It should be thorough, yet concise – it will be used in tool tips and detailed views.<br/>  Prescriptive guidance for resources: <br/>Read any <display.resource> <br/>Create or Update any <display.resource> <br/>Delete any <display.resource> <br/> <User Friendly Action Name> any <display.resources>  |
 | origin | **Optional.** The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.<br/> Default value is "user,system"<br/> Details below |
 | isDataAction | **Required.** Indicates whether the operation applies to data-plane. Set the value to `"true"` for data-plane operations and `"false"` for ARM/control-plane operations. | 
-| actionType | **Optional** Indicates the action type. Enum: "interalAction" which refers to actions that are for internal only APIs. |
+| actionType | **Optional** Indicates the action type. Enum: "InteralAction" which refers to actions that are for internal only APIs. |
 | properties | **Reserved for future use.  Optional.** |
 
 #### Origin details ####

--- a/v1.0/proxy-api-reference.md
+++ b/v1.0/proxy-api-reference.md
@@ -140,7 +140,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
     {
       "name": "{resourceProviderNamespace}/{resourceType}/{read|write|delete|action}",
       "isDataAction": false,
-      "actionType" : "InternalAction",
+      "actionType" : "Internal",
       "display": {
         "provider": "{Name of the provider for display purposes}",
         "resource": "{Name of the resource type for display purposes}",
@@ -179,7 +179,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
 | display.description | **Required**.The localized friendly description for the operation, as it should be shown to the user. It should be thorough, yet concise – it will be used in tool tips and detailed views.<br/>  Prescriptive guidance for resources: <br/>Read any <display.resource> <br/>Create or Update any <display.resource> <br/>Delete any <display.resource> <br/> <User Friendly Action Name> any <display.resources>  |
 | origin | **Optional.** The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.<br/> Default value is "user,system"<br/> Details below |
 | isDataAction | **Required.** Indicates whether the operation applies to data-plane. Set the value to `"true"` for data-plane operations and `"false"` for ARM/control-plane operations. | 
-| actionType | **Optional** Enum. Indicates the action type. "Interal" which refers to actions that are for internal only APIs. |
+| actionType | **Optional** Enum. Indicates the action type. "Internal" which refers to actions that are for internal only APIs. |
 | properties | **Reserved for future use.  Optional.** |
 
 #### Origin details ####

--- a/v1.0/proxy-api-reference.md
+++ b/v1.0/proxy-api-reference.md
@@ -135,12 +135,12 @@ This API is unique in that it is not scoped to a subscription – it is consider
 | api-version | Specifies the version of the protocol used to make this request. Format must match YYYY-MM-DD[-preview|-alpha|-beta|-rc|-privatepreview]. |
 
 #### Response ####
-
     {
     "value": [
     {
       "name": "{resourceProviderNamespace}/{resourceType}/{read|write|delete|action}",
-	    "isDataAction": "false",
+      "isDataAction": false,
+      "actionType" : "internalAction",
       "display": {
         "provider": "{Name of the provider for display purposes}",
         "resource": "{Name of the resource type for display purposes}",
@@ -153,7 +153,8 @@ This API is unique in that it is not scoped to a subscription – it is consider
     },
     {
       "name": "{resourceProviderNamespace}/{resourceType}/{read|write|delete|action}",
-	    "isDataAction": "false",
+      "isDataAction": false,
+      "actionType" : "internalAction",
       "display": {
         "provider": "{Name of the provider for display purposes}",
         "resource": "{Name of the resource type for display purposes}",
@@ -162,10 +163,11 @@ This API is unique in that it is not scoped to a subscription – it is consider
       },
       "origin": "user|system|user,system",
       "properties": { }
-    },
+    }
     ],
     "nextLink": "{originalRequestUrl}?$skipToken={opaqueString}"
     }
+
 
 | Element name | Description |
 | --- | --- |
@@ -176,7 +178,8 @@ This API is unique in that it is not scoped to a subscription – it is consider
 | display.operation  | **Required**.The localized friendly name for the operation, as it should be shown to the user. It should be concise (to fit in drop downs) but clear (i.e. self-documenting). It should use Title Casing and include the entity/resource to which it applies.<br/>  Prescriptive guidance: <br/> Read {Resource Type Name} <br/>Create or Update {Resource Type Name} <br/>Delete {Resource Type Name} <br/> <User Friendly Action Name> {Resource Type Name} <br/> As examples:Read Virtual Machine <br/>Create or Update Virtual Machine <br/>Delete Virtual Machine <br/> Restart Virtual Machine  |
 | display.description | **Required**.The localized friendly description for the operation, as it should be shown to the user. It should be thorough, yet concise – it will be used in tool tips and detailed views.<br/>  Prescriptive guidance for resources: <br/>Read any <display.resource> <br/>Create or Update any <display.resource> <br/>Delete any <display.resource> <br/> <User Friendly Action Name> any <display.resources>  |
 | origin | **Optional.** The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.<br/> Default value is "user,system"<br/> Details below |
-| isDataAction | **Required.** Indicates whether the operation applies to data-plane. Set the value to `"true"` for data-plane operations and `"false"` for ARM/control-plane operations. |
+| isDataAction | **Required.** Indicates whether the operation applies to data-plane. Set the value to `"true"` for data-plane operations and `"false"` for ARM/control-plane operations. | 
+| actionType | **Optional** Indicates the action type. Enum: "interalAction" which refers to actions that are for internal only APIs. |
 | properties | **Reserved for future use.  Optional.** |
 
 #### Origin details ####

--- a/v1.0/proxy-api-reference.md
+++ b/v1.0/proxy-api-reference.md
@@ -154,7 +154,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
     {
       "name": "{resourceProviderNamespace}/{resourceType}/{read|write|delete|action}",
       "isDataAction": false,
-      "actionType" : "InternalAction",
+      "actionType" : "Internal",
       "display": {
         "provider": "{Name of the provider for display purposes}",
         "resource": "{Name of the resource type for display purposes}",
@@ -179,7 +179,7 @@ This API is unique in that it is not scoped to a subscription – it is consider
 | display.description | **Required**.The localized friendly description for the operation, as it should be shown to the user. It should be thorough, yet concise – it will be used in tool tips and detailed views.<br/>  Prescriptive guidance for resources: <br/>Read any <display.resource> <br/>Create or Update any <display.resource> <br/>Delete any <display.resource> <br/> <User Friendly Action Name> any <display.resources>  |
 | origin | **Optional.** The intended executor of the operation; governs the display of the operation in the RBAC UX and the audit logs UX.<br/> Default value is "user,system"<br/> Details below |
 | isDataAction | **Required.** Indicates whether the operation applies to data-plane. Set the value to `"true"` for data-plane operations and `"false"` for ARM/control-plane operations. | 
-| actionType | **Optional** Indicates the action type. Enum: "InteralAction" which refers to actions that are for internal only APIs. |
+| actionType | **Optional** Enum. Indicates the action type. "Interal" which refers to actions that are for internal only APIs. |
 | properties | **Reserved for future use.  Optional.** |
 
 #### Origin details ####


### PR DESCRIPTION
Introducing an optional top level property - "actionType" which is an Enum, of possible categories of what type of action is exposed. 
Current value is "interalAction" which refers to actions that are for internal only APIs.